### PR TITLE
スタートアップ時のタイマーなどに関する修正

### DIFF
--- a/Omawari/App.xaml.cs
+++ b/Omawari/App.xaml.cs
@@ -48,6 +48,21 @@ namespace Omawari
         private static Forms.Timer Timer = new Forms.Timer();
         private static Forms.NotifyIcon NotifyIcon = new Forms.NotifyIcon();
 
+        public event EventHandler<PulsedEventArgs> Pulsed = null;
+        public event EventHandler Initalized = null;
+
+        protected void OnPulsed()
+        {
+            CheckAll();
+
+            Pulsed?.Invoke(this, new PulsedEventArgs(++WorkingMinutes));
+        }
+
+        protected void OnInitalized()
+        {
+            Initalized?.Invoke(this, EventArgs.Empty);
+        }
+
         public static Models.ScraperCollection ScraperCollection { get; private set; }
         public static AsyncObservableCollection<Models.ScrapingResult> UpdateLog { get; private set; }
         public static Models.GlobalSettings GlobalSettings { get; set; }
@@ -94,8 +109,10 @@ namespace Omawari
             });
 
             Timer.Interval = 60 * 1000;
-            Timer.Tick += (s, a) => { CheckAll(); WorkingMinutes++; };
+            Timer.Tick += (s, a) => { OnPulsed(); };
             if (GlobalSettings.AutoStart) Start();
+
+            OnInitalized();
         }
 
         private void Application_Exit(object sender, ExitEventArgs e)
@@ -160,6 +177,16 @@ namespace Omawari
         public static void ShowCaution(string message, int duration = 5 * 1000)
         {
             NotifyIcon.ShowBalloonTip(duration, App.Name, message, Forms.ToolTipIcon.Error);
+        }
+
+        public class PulsedEventArgs
+        {
+            public PulsedEventArgs(int workingMinutes)
+            {
+                WorkingMinutes = workingMinutes;
+            }
+
+            public int WorkingMinutes { get; set; }
         }
     }
 }

--- a/Omawari/ViewModels/MainViewModel.cs
+++ b/Omawari/ViewModels/MainViewModel.cs
@@ -17,9 +17,21 @@ namespace Omawari.ViewModels
     {
         public MainViewModel()
         {
+            var app = App.Current as App;
 
+            app.Initalized += (s, a) =>
+            {
+                UpdateTimerRelatedControls();
+            };
+
+            app.Pulsed += (s, a) =>
+            {
+                WorkingTimeMessage = a.WorkingMinutes != 1
+                    ? $"Working: {a.WorkingMinutes} times (Last pulse: {DateTime.Now})"
+                    : $"Working: {a.WorkingMinutes} time (Last pulse: {DateTime.Now})";
+            };
         }
-        
+
         private RelayCommand addScraperCommand = null;
         private RelayCommand editScraperCommand = null;
         private RelayCommand removeScraperCommand = null;
@@ -30,13 +42,20 @@ namespace Omawari.ViewModels
         private RelayCommand exitCommand = null;
         private RelayCommand checkAllScraperCommand = null;
         private RelayCommand settingsCommand = null;
+        private RelayCommand helpCommand = null;
 
         private ScraperCollection items = App.ScraperCollection;
         private ObservableCollection<Models.ScrapingResult> updateLog = App.UpdateLog;
         private Scraper selectedItem = null;
+        private string workingTimeMessage = null;
+        private string timerStatusMessage = null;
 
-        private string timerCommandLabel = "Start";
-        private RelayCommand helpCommand;
+        private void UpdateTimerRelatedControls()
+        {
+            StartCommand.RaiseCanExecuteChanged();
+            StopCommand.RaiseCanExecuteChanged();
+            TimerStatusMessage = $"Timer Enabled: {App.GetTimerIsEnabled()}";
+        }
 
         public RelayCommand StartCommand
         {
@@ -47,9 +66,7 @@ namespace Omawari.ViewModels
                 return startCommand = new RelayCommand(() =>
                 {
                     App.Start();
-                    StartCommand.RaiseCanExecuteChanged();
-                    StopCommand.RaiseCanExecuteChanged();
-                    OnPropertyChanged(nameof(StatusBarMessage));
+                    UpdateTimerRelatedControls();
                 }, () => !App.GetTimerIsEnabled());
             }
         }
@@ -63,9 +80,7 @@ namespace Omawari.ViewModels
                 return stopCommand = new RelayCommand(() =>
                 {
                     App.Stop();
-                    StartCommand.RaiseCanExecuteChanged();
-                    StopCommand.RaiseCanExecuteChanged();
-                    OnPropertyChanged(nameof(StatusBarMessage));
+                    UpdateTimerRelatedControls();
                 }, () => App.GetTimerIsEnabled());
             }
         }
@@ -230,15 +245,16 @@ namespace Omawari.ViewModels
             }
         }
 
-        public string TimerCommandLabel
+        public string TimerStatusMessage
         {
-            get { return timerCommandLabel; }
-            set { SetProperty(ref timerCommandLabel, value); }
+            get { return timerStatusMessage; }
+            set { SetProperty(ref timerStatusMessage, value); }
         }
 
-        public string StatusBarMessage
+        public string WorkingTimeMessage
         {
-            get { return $"Timer: {App.GetTimerIsEnabled()}"; }
+            get { return workingTimeMessage; }
+            set { SetProperty(ref workingTimeMessage, value); }
         }
     }
 }

--- a/Omawari/Views/MainWindow.xaml
+++ b/Omawari/Views/MainWindow.xaml
@@ -251,7 +251,8 @@
         </ListView>
 
         <StatusBar Grid.Row="5">
-            <StatusBarItem Content="{Binding ViewModel.StatusBarMessage}" />
+            <StatusBarItem Content="{Binding ViewModel.TimerStatusMessage}" />
+            <StatusBarItem Content="{Binding ViewModel.WorkingTimeMessage}" />
         </StatusBar>
     </Grid>
 </Window>


### PR DESCRIPTION
- 5801d922592af5455ade73ac9cfdf1c5df0e6153 に伴うリグレッションの修正（設定読み込みの非同期化に伴い、メインウィンドウのタイマー状態の取得タイミングがズレて、ボタンやステータスバーメッセージが正常な状態にセットされていなかった）
- それに伴うアプリケーションイベントの追加
- それを利用して、ステータスバーに総稼働時間を表示するように